### PR TITLE
Move fzaninotto/faker to optional dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
         "symfony/config": "~2.5",
         "symfony/form": "~2.5",
         "symfony/validator": "~2.5",
-        "twig/twig": "^1.12",
-        "fzaninotto/faker": "^1.5"
+        "twig/twig": "^1.12"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.5",
-        "bossa/phpspec2-expect": "~1.0"
+        "bossa/phpspec2-expect": "~1.0",
+        "fzaninotto/faker": "^1.5"
     },
     "config": {
         "bin-dir": "bin"
@@ -42,6 +42,7 @@
         }
     },
     "suggest": {
+        "fzaninotto/faker": "To use the dictionary provider",
         "knplabs/rad-fixtures-load": "Allows to autoregister the dictionary provider as an alice provider"
     }
 }


### PR DESCRIPTION
The dependency is not required most of the time so putting it in suggest makes more sense.