### PR TITLE
Don't hydrate CallableDictionary during serialization

### DIFF
--- a/spec/Knp/DictionaryBundle/Dictionary/CallableDictionarySpec.php
+++ b/spec/Knp/DictionaryBundle/Dictionary/CallableDictionarySpec.php
@@ -46,14 +46,22 @@ class CallableDictionarySpec extends ObjectBehavior
         expect(isset($dictionary['foo']))->toBe(false);
     }
 
-    function it_can_be_serialized_and_unserialized()
+    function it_contains_original_values_after_unserialization_if_the_original_dictionary_is_hydrated_first()
     {
-        $dictionary = $this->getWrappedObject();
+        // should hydrate the original dictionary
+        $this->getValues()->shouldReturn(array('foo' => 0, 'bar' => 1, 'baz' => 2));
 
-        $dictionary = unserialize(serialize($dictionary));
+        $dictionary = unserialize(serialize($this->getWrappedObject()));
 
         expect($dictionary['foo'])->toBe(0);
         expect(isset($dictionary['foo']))->toBe(true);
+    }
+
+    function it_contains_nothing_after_unserialization_if_the_original_dictionary_is_not_hydrated_first()
+    {
+        $dictionary = unserialize(serialize($this->getWrappedObject()));
+
+        expect(isset($dictionary['foo']))->toBe(false);
     }
 
     function it_provides_a_set_of_values()

--- a/src/Knp/DictionaryBundle/Dictionary/CallableDictionary.php
+++ b/src/Knp/DictionaryBundle/Dictionary/CallableDictionary.php
@@ -21,14 +21,18 @@ class CallableDictionary implements DictionaryInterface
      */
     private $callable;
 
+    /** @var bool */
+    private $initialized;
+
     /**
      * @param string   $name
      * @param callable $callable
      */
     public function __construct($name, callable $callable)
     {
-        $this->name     = $name;
-        $this->callable = $callable;
+        $this->name        = $name;
+        $this->callable    = $callable;
+        $this->initialized = false;
     }
 
     /**
@@ -116,11 +120,9 @@ class CallableDictionary implements DictionaryInterface
      */
     public function serialize()
     {
-        $this->hydrate();
-
         return serialize([
             'name'   => $this->name,
-            'values' => $this->values,
+            'values' => $this->values ?: array(),
         ]);
     }
 
@@ -131,8 +133,9 @@ class CallableDictionary implements DictionaryInterface
     {
         $data = unserialize($serialized);
 
-        $this->name   = $data['name'];
-        $this->values = $data['values'];
+        $this->name        = $data['name'];
+        $this->values      = $data['values'];
+        $this->initialized = true;
     }
 
     /**
@@ -140,7 +143,7 @@ class CallableDictionary implements DictionaryInterface
      */
     protected function hydrate()
     {
-        if (null !== $this->values) {
+        if ($this->initialized) {
             return;
         }
 
@@ -152,6 +155,7 @@ class CallableDictionary implements DictionaryInterface
             );
         }
 
-        $this->values = $values;
+        $this->values      = $values;
+        $this->initialized = true;
     }
 }


### PR DESCRIPTION
Hydrating CallableDictionary during serialization is causing symfony profiler to fail if the dictionary is not hydrated first and hydration process is failing. Moreover if the CallableDictionary hydrates from external resources it can lead to unneeded API requests.