### PR TITLE
Fixed twig template paths

### DIFF
--- a/src/Knp/DictionaryBundle/Resources/config/dictionary.xml
+++ b/src/Knp/DictionaryBundle/Resources/config/dictionary.xml
@@ -2,7 +2,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <services>
     <service id="knp_dictionary.data_collector.dictionary_data_collector" class="Knp\DictionaryBundle\DataCollector\DictionaryDataCollector">
-      <tag name="data_collector" template="KnpDictionaryBundle::layout.html.twig" id="dictionary"/>
+        <tag name="data_collector" template="@KnpDictionary/layout.html.twig" id="dictionary"/>
     </service>
 
     <service id="knp_dictionary.dictionary.factory.factory_aggregate" class="Knp\DictionaryBundle\Dictionary\Factory\FactoryAggregate"/>

--- a/src/Knp/DictionaryBundle/Resources/views/layout.html.twig
+++ b/src/Knp/DictionaryBundle/Resources/views/layout.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block menu %}
 <span class="label {{ collector.dictionaries is empty ? 'disabled' }}">


### PR DESCRIPTION
With the symfony standard edition `3.4` this bundle doesn’t work.

![screenshot-2018-2-7 the profiler template knpdictionarybundle layout html twig for data collector dictionary does not exist](https://user-images.githubusercontent.com/113045/35929446-c9abb0d2-0c2f-11e8-9af7-6297df72a343.png)

Because the current paths require twig template engine. The engine has begun to be [deprecated](https://github.com/symfony/symfony/pull/21035) and its already remove from configuration: https://github.com/symfony/symfony-standard/commit/c24345762017e8d2d72434ce0055df6410c8f458