### PR TITLE
Update symfony supported versions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ DictionaryBundle
 Are you often tired to repeat static choices like gender or civility in your apps ?
 
 ## Requirements
-- Symfony >= 2.8
+- Symfony >= 3.0
 
 ## Installation
 Add the DictionaryBundle to your `composer.json`:


### PR DESCRIPTION
Since we require symfony components from version `~3.0` to `~4.0` I guess we can update the required symfony version to `~3.0`.