### PR TITLE
Remove Symfony Normalization for Key Value

### DIFF
--- a/src/Knp/DictionaryBundle/DependencyInjection/Configuration.php
+++ b/src/Knp/DictionaryBundle/DependencyInjection/Configuration.php
@@ -36,6 +36,7 @@ class Configuration implements ConfigurationInterface
                         ->children()
                             ->scalarNode('type')->defaultValue('value')->end()
                             ->arrayNode('content')
+                                ->normalizeKeys(false)
                                 ->prototype('scalar')->end()
                             ->end()
                             ->scalarNode('service')->end()


### PR DESCRIPTION
The Dictionary array defined in the YAML conf file are normalized by symfony therfore values with hyphens "-" are replaced with underscores "_".

A fix would be to add ->normalizeKeys(false) on the Dependency Injection Tree Builder configuration