### PR TITLE
Added ExtendedDictionary

### DIFF
--- a/spec/Knp/DictionaryBundle/Dictionary/ExtendedDictionarySpec.php
+++ b/spec/Knp/DictionaryBundle/Dictionary/ExtendedDictionarySpec.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace spec\Knp\DictionaryBundle\Dictionary;
+
+use Knp\DictionaryBundle\Dictionary\ExtendedDictionary;
+use Knp\DictionaryBundle\Dictionary;
+use Phpspec\ObjectBehavior;
+use Webmozart\Assert\Assert;
+
+class ExtendedDictionarySpec extends ObjectBehavior
+{
+    function let(Dictionary $initialDictionary, Dictionary $extendedDictionary) {
+        $initialDictionary->getValues()->willReturn(['foo1' => 'foo1', 'foo2' => 'foo2']);
+        $extendedDictionary->getValues()->willReturn(['bar1' => 'bar1', 'bar2' => 'bar2']);
+
+        $this->beConstructedWith('foo', $initialDictionary, $extendedDictionary);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ExtendedDictionary::class);
+    }
+
+    function it_is_a_dictionary()
+    {
+        $this->shouldImplement(Dictionary::class);
+    }
+
+    function it_access_to_value_like_an_array()
+    {
+        Assert::eq($this['foo1']->getWrappedObject(), 'foo1');
+        Assert::eq($this['foo2']->getWrappedObject(), 'foo2');
+        Assert::eq($this['bar1']->getWrappedObject(), 'bar1');
+        Assert::eq($this['bar2']->getWrappedObject(), 'bar2');
+    }
+
+    function its_getvalues_should_return_dictionary_values()
+    {
+        $this->getValues()->shouldReturn([
+            'foo1' => 'foo1',
+            'foo2' => 'foo2',
+            'bar1' => 'bar1',
+            'bar2' => 'bar2',
+        ]);
+    }
+
+    function its_getname_should_return_dictionary_name()
+    {
+        $this->getName()->shouldReturn('foo');
+    }
+}

--- a/spec/Knp/DictionaryBundle/Dictionary/Factory/ExtendedSpec.php
+++ b/spec/Knp/DictionaryBundle/Dictionary/Factory/ExtendedSpec.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace spec\Knp\DictionaryBundle\Dictionary\Factory;
+
+use PhpSpec\ObjectBehavior;
+use Knp\DictionaryBundle\Dictionary\Factory;
+use Knp\DictionaryBundle\Dictionary\Factory\FactoryAggregate;
+use Knp\DictionaryBundle\Dictionary;
+use Knp\DictionaryBundle\Dictionary\DictionaryRegistry;
+
+class ExtendedSpec extends ObjectBehavior
+{
+    function let(
+        FactoryAggregate $factoryAggregate,
+        DictionaryRegistry $registry
+    ) {
+        $this->beConstructedWith($factoryAggregate, $registry);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(Factory\Extended::class);
+    }
+
+    function it_is_a_factory()
+    {
+        $this->shouldHaveType(Factory::class);
+    }
+
+    function it_supports_specific_config()
+    {
+        $this->supports(['extends' => 'my_dictionary'])->shouldReturn(true);
+    }
+
+    function it_creates_a_dictionary(
+        $factoryAggregate,
+        $registry,
+        Dictionary $initialDictionary,
+        Dictionary $extendsDictionary
+    ) {
+        $config = [
+            'content' => ['bar1', 'bar2', 'bar3'],
+        ];
+
+        $initialDictionary->getValues()->willReturn(['foo1', 'foo2']);
+        $extendsDictionary->getValues()->willReturn(['bar1', 'bar2', 'bar3']);
+
+        $factoryAggregate->create('yolo', $config)->willReturn($extendsDictionary);
+        $registry->get('initial_dictionary')->willReturn($initialDictionary);
+
+        $config = array_merge($config, ['extends' => 'initial_dictionary']);
+        $factoryAggregate->supports($config)->willReturn(true);
+
+        $dictionary = $this->create('yolo', $config);
+
+        $dictionary->getName()->shouldBe('yolo');
+        $dictionary->getValues()->shouldBe(['foo1', 'foo2', 'bar1', 'bar2', 'bar3']);
+    }
+}

--- a/src/Knp/DictionaryBundle/DependencyInjection/Configuration.php
+++ b/src/Knp/DictionaryBundle/DependencyInjection/Configuration.php
@@ -35,6 +35,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->children()
                             ->scalarNode('type')->defaultValue('value')->end()
+                            ->scalarNode('extends')->end()
                             ->arrayNode('content')
                                 ->normalizeKeys(false)->prototype('scalar')->end()
                             ->end()

--- a/src/Knp/DictionaryBundle/Dictionary/ExtendedDictionary.php
+++ b/src/Knp/DictionaryBundle/Dictionary/ExtendedDictionary.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Knp\DictionaryBundle\Dictionary;
+
+use ArrayIterator;
+use Knp\DictionaryBundle\Dictionary;
+
+class ExtendedDictionary implements Dictionary
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var Dictionary
+     */
+    private $initialDictionary;
+
+    /**
+     * @var Dictionary
+     */
+    private $extendedDictionary;
+
+    /**
+     * @var array
+     */
+    private $computedValues = null;
+
+    /**
+     * @param string $name
+     * @param Dictionary $initialDictionary
+     * @param Dictionary $extendedDictionary
+     */
+    public function __construct(
+        string $name,
+        Dictionary $initialDictionary,
+        Dictionary $extendedDictionary
+    ) {
+        $this->name               = $name;
+        $this->initialDictionary  = $initialDictionary;
+        $this->extendedDictionary = $extendedDictionary;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValues(): array
+    {
+        $this->ensureComputedValues();
+
+        return $this->computedValues;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getKeys(): array
+    {
+        $this->ensureComputedValues();
+
+        return array_keys($this->computedValues);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($offset)
+    {
+        return
+            $this->extendedDictionary->offsetExists($offset)
+            || $this->initialDictionary->offsetExists($offset)
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset)
+    {
+        $this->ensureComputedValues();
+
+        return $this->computedValues[$offset];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->clearComputedValues();
+
+        if ($this->extendedDictionary->offsetExists($offset)) {
+            return $this->extendedDictionary->offsetSet($offset, $value);
+        }
+
+        if ($this->initialDictionary->offsetExists($offset)) {
+            return $this->extendedDictionary->offsetSet($offset, $value);
+        }
+
+        return $this->extendedDictionary->offsetSet($offset, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetUnset($offset)
+    {
+        $this->clearComputedValues();
+
+        if ($this->extendedDictionary->offsetExists($offset)) {
+            $this->extendedDictionary->offsetUnset($offset);
+        }
+
+        if ($this->initialDictionary->offsetExists($offset)) {
+            $this->extendedDictionary->offsetUnset($offset);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        $this->ensureComputedValues();
+
+        return new ArrayIterator($this->computedValues);
+    }
+
+    private function computeValues()
+    {
+        $this->computedValues = array_merge(
+            $this->initialDictionary->getValues(),
+            $this->extendedDictionary->getValues()
+       );
+    }
+
+    private function ensureComputedValues()
+    {
+        if (null === $this->computedValues) {
+            $this->computeValues();
+        }
+    }
+
+    private function clearComputedValues()
+    {
+        $this->computedValues = null;
+    }
+}

--- a/src/Knp/DictionaryBundle/Dictionary/Factory/Extended.php
+++ b/src/Knp/DictionaryBundle/Dictionary/Factory/Extended.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Knp\DictionaryBundle\Dictionary\Factory;
+
+use InvalidArgumentException;
+use Knp\DictionaryBundle\Dictionary\DictionaryRegistry;
+use Knp\DictionaryBundle\Dictionary\Factory;
+use Knp\DictionaryBundle\Dictionary\Factory\FactoryAggregate;
+use Knp\DictionaryBundle\Dictionary;
+use Knp\DictionaryBundle\Dictionary\ExtendedDictionary;
+
+class Extended implements Factory
+{
+    /**
+     * @var FactoryAggregate
+     */
+    private $factoryAggregate;
+
+    /**
+     * @var DictionaryRegistry
+     */
+    private $dictionaryRegistry;
+
+    /**
+     * @param FactoryAggregate $factoryAggregate
+     * @param DictionaryRegistry $registry
+     */
+    public function __construct(
+        FactoryAggregate $factoryAggregate,
+        DictionaryRegistry $registry
+    ) {
+        $this->factoryAggregate = $factoryAggregate;
+        $this->registry         = $registry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(string $name, array $config): Dictionary
+    {
+        if (false === $this->factoryAggregate->supports($config)) {
+            throw new InvalidArgumentException(sprintf(
+                'The dictionary with named "%s" cannot be created.',
+                $name
+            ));
+        }
+
+        $extends = $config['extends'];
+        unset($config['extends']);
+
+        $extendedDictionary = $this->factoryAggregate->create($name, $config);
+        $initialDictionary = $this->registry->get($extends);
+
+        return new ExtendedDictionary($name, $initialDictionary, $extendedDictionary);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(array $config): bool
+    {
+        return isset($config['extends']);
+    }
+}

--- a/src/Knp/DictionaryBundle/Resources/config/dictionary.xml
+++ b/src/Knp/DictionaryBundle/Resources/config/dictionary.xml
@@ -7,6 +7,12 @@
 
     <service id="knp_dictionary.dictionary.factory.factory_aggregate" class="Knp\DictionaryBundle\Dictionary\Factory\FactoryAggregate"/>
 
+    <service id="knp_dictionary.dictionary.factory.extended_factory" class="Knp\DictionaryBundle\Dictionary\Factory\Extended">
+        <argument type="service" id="knp_dictionary.dictionary.factory.factory_aggregate"/>
+        <argument type="service" id="knp_dictionary.dictionary.dictionary_registry"/>
+        <tag name="knp_dictionary.factory"/>
+    </service>
+
     <service id="knp_dictionary.dictionary.factory.value" class="Knp\DictionaryBundle\Dictionary\Factory\Value">
         <argument type="service" id="knp_dictionary.dictionary.value_transformer.transformer_aggregate"/>
         <tag name="knp_dictionary.factory"/>


### PR DESCRIPTION
Dictionary inheritance system (mentioned in #70).

```yaml
knp_dictionary:
  dictionaries:
    payment_mode:
      type: key_value
      content:
        card: "credit card"
        none: "none"

    extended_payment_mode:
      type: key_value
      extends: payment_mode
      content:
        bank_transfert: "Bank transfert"
        other: "Other"
```

Result:
```php
var_dump($dictionaryRegistry->get('extended_payment_mode'));
```
```
Array (
    "card" => "credit card",
    "none" => "none",
    "bank_transfert" => "Bank transfert",
    "other" => "Other"
)
```