### PR TITLE
Add type to constraint violation if different from values.

### DIFF
--- a/spec/Knp/DictionaryBundle/Validator/Constraints/DictionaryValidatorSpec.php
+++ b/spec/Knp/DictionaryBundle/Validator/Constraints/DictionaryValidatorSpec.php
@@ -48,9 +48,9 @@ class DictionaryValidatorSpec extends ObjectBehavior
         $context->addViolation(
             "The key {{ key }}{{ keyType }} doesn't exist in the given dictionary. {{ keys }}{{ keysType }} available.",
             [
-                '{{ key }}' => 'the_unexisting_key',
+                '{{ key }}'      => 'the_unexisting_key',
                 '{{ keyType }}'  => '',
-                '{{ keys }}' => 'the_key',
+                '{{ keys }}'     => 'the_key',
                 '{{ keysType }}' => '',
             ]
         )->shouldBeCalled();
@@ -67,9 +67,9 @@ class DictionaryValidatorSpec extends ObjectBehavior
         $context->addViolation(
             "The key {{ key }}{{ keyType }} doesn't exist in the given dictionary. {{ keys }}{{ keysType }} available.",
             [
-                '{{ key }}' => '0',
+                '{{ key }}'      => '0',
                 '{{ keyType }}'  => ' (string)',
-                '{{ keys }}' => 0,
+                '{{ keys }}'     => 0,
                 '{{ keysType }}' => ' (integer)',
             ]
         )->shouldBeCalled();

--- a/spec/Knp/DictionaryBundle/Validator/Constraints/DictionaryValidatorSpec.php
+++ b/spec/Knp/DictionaryBundle/Validator/Constraints/DictionaryValidatorSpec.php
@@ -61,7 +61,7 @@ class DictionaryValidatorSpec extends ObjectBehavior
     function it_adds_violation_for_an_unmathching_key_type($context, Dictionary $dictionary)
     {
         $dictionary->getName()->willReturn('dico');
-        $dictionary->getKeys()->willReturn([0]);
+        $dictionary->getKeys()->willReturn(['a', 'foo', 0, 1]);
         $constraint = new Constraint(['name' => 'dico']);
 
         $context->addViolation(
@@ -69,8 +69,8 @@ class DictionaryValidatorSpec extends ObjectBehavior
             [
                 '{{ key }}'      => '0',
                 '{{ keyType }}'  => ' (string)',
-                '{{ keys }}'     => 0,
-                '{{ keysType }}' => ' (integer)',
+                '{{ keys }}'     => 'a, foo, 0, 1',
+                '{{ keysType }}' => ' (0 is integer)',
             ]
         )->shouldBeCalled();
 

--- a/spec/Knp/DictionaryBundle/Validator/Constraints/DictionaryValidatorSpec.php
+++ b/spec/Knp/DictionaryBundle/Validator/Constraints/DictionaryValidatorSpec.php
@@ -45,9 +45,36 @@ class DictionaryValidatorSpec extends ObjectBehavior
     {
         $constraint = new Constraint(['name' => 'dico']);
 
-        $context->addViolation("The key {{ key }} doesn't exist in the given dictionary. {{ keys }} available.", ['{{ key }}' => 'the_unexisting_key', '{{ keys }}' => 'the_key'])->shouldBeCalled();
+        $context->addViolation(
+            "The key {{ key }}{{ keyType }} doesn't exist in the given dictionary. {{ keys }}{{ keysType }} available.",
+            [
+                '{{ key }}' => 'the_unexisting_key',
+                '{{ keyType }}'  => '',
+                '{{ keys }}' => 'the_key',
+                '{{ keysType }}' => '',
+            ]
+        )->shouldBeCalled();
 
         $this->validate('the_unexisting_key', $constraint);
+    }
+
+    function it_adds_violation_for_an_unmathching_key_type($context, Dictionary $dictionary)
+    {
+        $dictionary->getName()->willReturn('dico');
+        $dictionary->getKeys()->willReturn([0]);
+        $constraint = new Constraint(['name' => 'dico']);
+
+        $context->addViolation(
+            "The key {{ key }}{{ keyType }} doesn't exist in the given dictionary. {{ keys }}{{ keysType }} available.",
+            [
+                '{{ key }}' => '0',
+                '{{ keyType }}'  => ' (string)',
+                '{{ keys }}' => 0,
+                '{{ keysType }}' => ' (integer)',
+            ]
+        )->shouldBeCalled();
+
+        $this->validate('0', $constraint);
     }
 
     function it_throw_exception_form_unknown_constraints()

--- a/src/Knp/DictionaryBundle/Validator/Constraints/Dictionary.php
+++ b/src/Knp/DictionaryBundle/Validator/Constraints/Dictionary.php
@@ -20,8 +20,11 @@ class Dictionary extends Constraint
     /**
      * @var string
      */
-    public $message = "The key {{ key }} doesn't exist in the given dictionary. {{ keys }} available.";
+    public $message = "The key {{ key }}{{ keyType }} doesn't exist in the given dictionary. {{ keys }}{{ keysType }} available.";
 
+    /**
+     * {@inheritdoc}
+     */
     public function validatedBy()
     {
         return DictionaryValidator::class;

--- a/src/Knp/DictionaryBundle/Validator/Constraints/DictionaryValidator.php
+++ b/src/Knp/DictionaryBundle/Validator/Constraints/DictionaryValidator.php
@@ -35,9 +35,17 @@ class DictionaryValidator extends ConstraintValidator
         $values     = $dictionary->getKeys();
 
         if (!\in_array($value, $values, true)) {
+            $valueType = gettype($value);
+            $dictionaryFirstType = gettype($values[0]);
+            $diffType = $valueType !== $dictionaryFirstType;
             $this->context->addViolation(
                 $constraint->message,
-                ['{{ key }}' => $value, '{{ keys }}' => implode(', ', $values)]
+                [
+                    '{{ key }}'  => $value,
+                    '{{ keyType }}'  => $diffType ? sprintf(' (%s)', $valueType) : '',
+                    '{{ keys }}' => implode(', ', $values),
+                    '{{ keysType }}' =>  ($diffType ? sprintf(' (%s)', $dictionaryFirstType) : ''),
+                ]
             );
         }
     }

--- a/src/Knp/DictionaryBundle/Validator/Constraints/DictionaryValidator.php
+++ b/src/Knp/DictionaryBundle/Validator/Constraints/DictionaryValidator.php
@@ -40,21 +40,23 @@ class DictionaryValidator extends ConstraintValidator
         $dictionary = $this->dictionaries[$constraint->name];
         $keys       = $dictionary->getKeys();
 
-        $dictionaryFirstType = null;
-        if (count($keys)) {
-            $dictionaryFirstType = gettype(reset($keys));
-        }
-
         if (false === in_array($value, $keys, true)) {
-            $valueType = gettype($value);
-            $isTypeDifferent = $valueType !== $dictionaryFirstType;
+            if (true === in_array($value, $keys)) {
+                $valueType = gettype($value);
+                foreach ($keys as $key) {
+                    if ($key == $value) {
+                        $keyValue = $key;
+                        $keyType = gettype($key);                        
+                    }
+                }
+            }
             $this->context->addViolation(
                 $constraint->message,
                 [
-                    '{{ key }}'  => $value,
-                    '{{ keyType }}'  => $isTypeDifferent ? sprintf(' (%s)', $valueType) : '',
-                    '{{ keys }}' => implode(', ', $keys),
-                    '{{ keysType }}' =>  ($isTypeDifferent ? sprintf(' (%s)', $dictionaryFirstType) : ''),
+                    '{{ key }}'      => $value,
+                    '{{ keyType }}'  => isset($valueType) ? sprintf(' (%s)', $valueType) : '',
+                    '{{ keys }}'     => implode(', ', $keys),
+                    '{{ keysType }}' => ((isset($keyValue) && isset($keyType)) ? sprintf(' (%s is %s)', $keyValue, $keyType) : ''),
                 ]
             );
         }


### PR DESCRIPTION
Avoid useless error message : «The key 0 doesn't exist in the given dictionary. 0,1,2 available»
Replace it with this : «The key 0 (string) doesn't exist in the given dictionary. 0,1,2 (integer) available»