### PR TITLE
Fixed Symfony 5 broken collector

### DIFF
--- a/src/Knp/DictionaryBundle/DataCollector/DictionaryDataCollector.php
+++ b/src/Knp/DictionaryBundle/DataCollector/DictionaryDataCollector.php
@@ -11,9 +11,7 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 
 class DictionaryDataCollector extends DataCollector
 {
-    public function collect(Request $request, Response $response, Exception $exception = null): void
-    {
-    }
+    use SymfonyCompatibilityTrait;
 
     /**
      * @param mixed[] $keys

--- a/src/Knp/DictionaryBundle/DataCollector/SymfonyCompatibilityTrait.php
+++ b/src/Knp/DictionaryBundle/DataCollector/SymfonyCompatibilityTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DictionaryBundle\DataCollector;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Kernel;
+
+if (Kernel::VERSION_ID >= 40308) {
+    trait SymfonyCompatibilityTrait
+    {
+        /**
+         * {@inheritdoc}
+         */
+        public function collect(Request $request, Response $response, \Throwable $exception = null): void
+        {
+        }
+    }
+} else {
+    trait SymfonyCompatibilityTrait
+    {
+        /**
+         * {@inheritdoc}
+         */
+        public function collect(Request $request, Response $response, \Exception $exception = null): void
+        {
+        }
+    }
+}


### PR DESCRIPTION
Hello there!

Following #120 I tried to move back from my fork to the official bundle, and encountered the following issue : 

```
!!  [19-Feb-2020 16:08:35 UTC] PHP Fatal error:  Declaration of Knp\DictionaryBundle\DataCollector\DictionaryDataCollector::collect(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\HttpFoundation\Response $response, ?Exception $exception = NULL): void must be compatible with Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface::collect(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\HttpFoundation\Response $response, ?Throwable $exception = NULL) in /app/cozysoft/vendor/knplabs/dictionary-bundle/src/Knp/DictionaryBundle/DataCollector/DictionaryDataCollector.php on line 14
```

So here's a fix inspired by what they did on https://github.com/geocoder-php/BazingaGeocoderBundle