### PR TITLE
add ReturnTypeWillChange attribute to avoid deprecation warnings

### DIFF
--- a/src/Knp/DictionaryBundle/Dictionary/Collection.php
+++ b/src/Knp/DictionaryBundle/Dictionary/Collection.php
@@ -41,6 +41,7 @@ final class Collection implements ArrayAccess, Countable, IteratorAggregate
         $this->dictionaries[$dictionary->getName()] = $dictionary;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return \array_key_exists($offset, $this->dictionaries);
@@ -53,6 +54,7 @@ final class Collection implements ArrayAccess, Countable, IteratorAggregate
      *
      * @return Dictionary<mixed>
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (!$this->offsetExists($offset)) {
@@ -74,6 +76,7 @@ final class Collection implements ArrayAccess, Countable, IteratorAggregate
         throw new RuntimeException('It is not possible to remove a dictionary from the collection.');
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->dictionaries);

--- a/src/Knp/DictionaryBundle/Dictionary/Traceable.php
+++ b/src/Knp/DictionaryBundle/Dictionary/Traceable.php
@@ -58,6 +58,7 @@ final class Traceable implements Dictionary
         return $this->dictionary->offsetExists($offset);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $this->markAsUsed();


### PR DESCRIPTION
This PR will get rid of the deprecation notices.

However, it'd be better to actually add the return type, but I wasn't sure if that could cause a BC break.  