### PR TITLE
Fix Symfony PHPStan compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "phpspec/prophecy": "1.22.0",
         "phpstan/extension-installer": "1.4.3",
         "phpstan/phpstan": "2.1.27",
-        "phpstan/phpstan-symfony": "2.0.6",
+        "phpstan/phpstan-symfony": "2.0.20",
         "rector/rector": "2.1.7",
         "symfony/twig-bridge": "^5.4 || ^6.4 || ^7.0",
         "symfony/var-dumper": "^5.4 || ^6.4 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "twig/twig": "^2.15.3 || ^3.4.3"
     },
     "require-dev": {
+        "composer/semver": "3.4.0",
         "fakerphp/faker": "1.24.1",
         "friends-of-phpspec/phpspec-code-coverage": "6.5.0",
         "friendsofphp/php-cs-fixer": "3.75.0",

--- a/phpstan-symfony-version.neon.php
+++ b/phpstan-symfony-version.neon.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
+
+return InstalledVersions::satisfies(new VersionParser(), 'symfony/config', '<7.4')
+    ? ['parameters' => ['stubFiles' => [__DIR__.'/phpstan/stubs/TreeBuilder.stub']]]
+    : [];

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,6 @@
+includes:
+    - phpstan-symfony-version.neon.php
+
 parameters:
     level: 8
     paths:

--- a/phpstan/stubs/TreeBuilder.stub
+++ b/phpstan/stubs/TreeBuilder.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Config\Definition\Builder;
+
+/**
+ * @template T of 'array'|'variable'|'scalar'|'string'|'boolean'|'integer'|'float'|'enum'
+ */
+class TreeBuilder
+{
+}

--- a/src/Knp/DictionaryBundle/DependencyInjection/Configuration.php
+++ b/src/Knp/DictionaryBundle/DependencyInjection/Configuration.php
@@ -14,6 +14,9 @@ final class Configuration implements ConfigurationInterface
      */
     private const CONFIG_NAME = 'knp_dictionary';
 
+    /**
+     * @return TreeBuilder<'array'>
+     */
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder    = new TreeBuilder(self::CONFIG_NAME);


### PR DESCRIPTION
## Summary

Fix PHPStan compatibility across supported Symfony versions.

## Details

- update phpstan-symfony for Symfony 7.4 generic config builders
- load a minimal TreeBuilder generic stub only for Symfony versions before 7.4
- keep native Symfony 7.4 generic types without suppressing PHPStan errors
- validate PHPStan across Symfony 5.4, 6.4, and 7.4