### PR TITLE
Add named dictionary autowiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,25 @@ knp_dictionary:
       - Ms
 ```
 
-To inject a configured dictionary directly, type-hint `Dictionary` and name the
-argument `<dictionaryName>Dictionary`. Names are normalized to camel case, so
-`civility` maps to
-`$civilityDictionary`.
+To inject a configured dictionary directly, type-hint `Dictionary` and select
+its name with Symfony's `#[Target]` attribute:
+
+```php
+use Knp\DictionaryBundle\Dictionary;
+use Symfony\Component\DependencyInjection\Attribute\Target;
+
+final class UserManager
+{
+    public function __construct(
+        #[Target('civility.dictionary')]
+        private Dictionary $dictionary,
+    ) {}
+}
+```
+
+Selecting by argument name remains supported for compatibility. Use
+`<dictionaryName>Dictionary`; names are normalized to camel case, so `civility`
+maps to `$civilityDictionary`:
 
 ```php
 use Knp\DictionaryBundle\Dictionary;
@@ -64,22 +79,6 @@ final class UserManager
 
 An existing named `Dictionary` autowiring alias takes precedence and is not
 replaced by a configured dictionary.
-
-To use a different argument name, select the dictionary with Symfony's `#[Target]`
-attribute:
-
-```php
-use Knp\DictionaryBundle\Dictionary;
-use Symfony\Component\DependencyInjection\Attribute\Target;
-
-final class UserManager
-{
-    public function __construct(
-        #[Target('civility.dictionary')]
-        private Dictionary $dictionary,
-    ) {}
-}
-```
 
 Names that are invalid PHP argument names after normalization, or names that
 normalize to the same argument name (for example, `foo-bar` and `foo_bar`), do

--- a/README.md
+++ b/README.md
@@ -41,22 +41,69 @@ Define dictionaries in your config.yml file:
 ```yaml
 knp_dictionary:
   dictionaries:
-    my_dictionary: # your dictionary name
-      - Foo # your dictionary content
-      - Bar
-      - Baz
+    civility:
+      - Mr
+      - Ms
 ```
 
-You will be able to retrieve it by injecting the Collection service and accessing the dictionary by its key
+Configured dictionaries can be injected by type-hinting `Dictionary` and naming
+the argument after the dictionary followed by `Dictionary`. Dictionary names are
+normalized to camel case, so `entity_class_icons` maps to
+`$entityClassIconsDictionary`.
 
 ```php
+use Knp\DictionaryBundle\Dictionary;
 
-    private Dictionary $myDictionary;
+final class UserManager
+{
     public function __construct(
-        \Knp\DictionaryBundle\Dictionary\Collection $dictionaries)
+        private Dictionary $civilityDictionary,
+    ) {}
+}
+```
+
+Use Symfony's `Target` attribute when the argument needs a different name:
+
+```php
+use Knp\DictionaryBundle\Dictionary;
+use Symfony\Component\DependencyInjection\Attribute\Target;
+
+final class UserManager
+{
+    public function __construct(
+        #[Target('civility.dictionary')]
+        private Dictionary $dictionary,
+    ) {}
+}
+```
+
+Names that cannot become valid PHP argument names, or names that become
+ambiguous after normalization (for example, `foo-bar` and `foo_bar`), do not
+receive an automatic autowiring alias. They can be wired explicitly:
+
+```yaml
+services:
+  App\Service\MyService:
+    arguments:
+      $dictionary: '@knp_dictionary.dictionary.foo-bar'
+```
+
+You can also inject the collection when the dictionary must be selected
+dynamically or cannot be autowired by name:
+
+```php
+use Knp\DictionaryBundle\Dictionary;
+use Knp\DictionaryBundle\Dictionary\Collection;
+
+final class UserManager
+{
+    private Dictionary $dictionary;
+
+    public function __construct(Collection $dictionaries)
     {
-        $this->myDictionary = $dictionaries['my_dictionary'];
+        $this->dictionary = $dictionaries['civility'];
     }
+}
 ```
 
 ## Dictionary form type
@@ -70,7 +117,7 @@ public function buildForm(FormBuilderInterface $builder, array $options)
 {
     $builder
         ->add('civility', DictionaryType::class, array(
-            'name' => 'my_dictionary'
+            'name' => 'civility'
         ))
     ;
 }

--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ Define dictionaries in your config.yml file:
 ```yaml
 knp_dictionary:
   dictionaries:
-    civility:
-      - Mr
+    civility: # your dictionary name
+      - Mr    # your dictionary content
       - Ms
 ```
 
 To inject a configured dictionary directly, type-hint `Dictionary` and name the
 argument `<dictionaryName>Dictionary`. Names are normalized to camel case, so
-`entity_class_icons` maps to
-`$entityClassIconsDictionary`.
+`civility` maps to
+`$civilityDictionary`.
 
 ```php
 use Knp\DictionaryBundle\Dictionary;
@@ -65,7 +65,7 @@ final class UserManager
 An existing named `Dictionary` autowiring alias takes precedence and is not
 replaced by a configured dictionary.
 
-To use a different argument name, select the dictionary with Symfony's `Target`
+To use a different argument name, select the dictionary with Symfony's `#[Target]`
 attribute:
 
 ```php
@@ -83,27 +83,17 @@ final class UserManager
 
 Names that are invalid PHP argument names after normalization, or names that
 normalize to the same argument name (for example, `foo-bar` and `foo_bar`), do
-not receive an automatic autowiring alias. Wire them explicitly:
-
-```yaml
-services:
-  App\Service\MyService:
-    arguments:
-      $dictionary: '@knp_dictionary.dictionary.foo-bar'
-```
-
-Inject the collection instead when selecting a dictionary dynamically or when
-named autowiring is unavailable:
+not receive an automatic autowiring alias. Inject the collection instead for
+these names or when selecting a dictionary dynamically:
 
 ```php
 use Knp\DictionaryBundle\Dictionary;
-use Knp\DictionaryBundle\Dictionary\Collection;
 
 final class UserManager
 {
     private Dictionary $dictionary;
 
-    public function __construct(Collection $dictionaries)
+    public function __construct(Dictionary\Collection $dictionaries)
     {
         $this->dictionary = $dictionaries['civility'];
     }

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ final class UserManager
 }
 ```
 
+An existing named `Dictionary` autowiring alias takes precedence and is not
+replaced by a configured dictionary.
+
 To use a different argument name, select the dictionary with Symfony's `Target`
 attribute:
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ knp_dictionary:
       - Ms
 ```
 
-Configured dictionaries can be injected by type-hinting `Dictionary` and naming
-the argument after the dictionary followed by `Dictionary`. Dictionary names are
-normalized to camel case, so `entity_class_icons` maps to
+To inject a configured dictionary directly, type-hint `Dictionary` and name the
+argument `<dictionaryName>Dictionary`. Names are normalized to camel case, so
+`entity_class_icons` maps to
 `$entityClassIconsDictionary`.
 
 ```php
@@ -62,7 +62,8 @@ final class UserManager
 }
 ```
 
-Use Symfony's `Target` attribute when the argument needs a different name:
+To use a different argument name, select the dictionary with Symfony's `Target`
+attribute:
 
 ```php
 use Knp\DictionaryBundle\Dictionary;
@@ -77,9 +78,9 @@ final class UserManager
 }
 ```
 
-Names that cannot become valid PHP argument names, or names that become
-ambiguous after normalization (for example, `foo-bar` and `foo_bar`), do not
-receive an automatic autowiring alias. They can be wired explicitly:
+Names that are invalid PHP argument names after normalization, or names that
+normalize to the same argument name (for example, `foo-bar` and `foo_bar`), do
+not receive an automatic autowiring alias. Wire them explicitly:
 
 ```yaml
 services:
@@ -88,8 +89,8 @@ services:
       $dictionary: '@knp_dictionary.dictionary.foo-bar'
 ```
 
-You can also inject the collection when the dictionary must be selected
-dynamically or cannot be autowired by name:
+Inject the collection instead when selecting a dictionary dynamically or when
+named autowiring is unavailable:
 
 ```php
 use Knp\DictionaryBundle\Dictionary;
@@ -135,7 +136,7 @@ use Knp\DictionaryBundle\Validator\Constraints\Dictionary;
 class User
 {
     #[ORM\Column]
-    #[Dictionary(name: 'my_dictionary')]
+    #[Dictionary(name: 'civility')]
     private $civility;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ final class UserManager
 }
 ```
 
-Selecting by argument name remains supported for compatibility. Use
-`<dictionaryName>Dictionary`; names are normalized to camel case, so `civility`
+You can also select a dictionary by naming the argument
+`<dictionaryName>Dictionary`. Names are normalized to camel case, so `civility`
 maps to `$civilityDictionary`:
 
 ```php
@@ -77,8 +77,7 @@ final class UserManager
 }
 ```
 
-An existing named `Dictionary` autowiring alias takes precedence and is not
-replaced by a configured dictionary.
+An existing named `Dictionary` autowiring alias takes precedence.
 
 Names that are invalid PHP argument names after normalization, or names that
 normalize to the same argument name (for example, `foo-bar` and `foo_bar`), do

--- a/spec/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPassSpec.php
+++ b/spec/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPassSpec.php
@@ -168,6 +168,8 @@ final class DictionaryBuildingPassSpec extends ObjectBehavior
             'dictionaries' => [
                 'vote'               => ['yes', 'no'],
                 'entity_class_icons' => ['user', 'group'],
+                'foo'                => ['base'],
+                'foo.autowiring'     => ['nested'],
             ],
         ]], $container);
         (new KnpDictionaryBundle())->build($container);
@@ -183,6 +185,11 @@ final class DictionaryBuildingPassSpec extends ObjectBehavior
         Assert::same($consumer->voteDictionary->getName(), 'vote');
         Assert::same($consumer->entityClassIconsDictionary->getName(), 'entity_class_icons');
         Assert::same($consumer->dictionary->getName(), 'vote');
+
+        $dictionaries = $container->get(Collection::class);
+        Assert::isInstanceOf($dictionaries, Collection::class);
+        Assert::same($dictionaries['foo']->getName(), 'foo');
+        Assert::same($dictionaries['foo.autowiring']->getName(), 'foo.autowiring');
     }
 
     function it_keeps_invalid_and_ambiguous_dictionary_names_out_of_named_autowiring()
@@ -212,9 +219,9 @@ final class DictionaryBuildingPassSpec extends ObjectBehavior
         Assert::true($container->hasDefinition('knp_dictionary.dictionary.foo_bar'));
         Assert::false($container->hasAlias(Dictionary::class.' $123StatusDictionary'));
         Assert::false($container->hasAlias(Dictionary::class.' $fooBarDictionary'));
-        Assert::false($container->hasDefinition('knp_dictionary.dictionary.123_status.autowiring'));
-        Assert::false($container->hasDefinition('knp_dictionary.dictionary.foo-bar.autowiring'));
-        Assert::false($container->hasDefinition('knp_dictionary.dictionary.foo_bar.autowiring'));
+        Assert::false($container->hasDefinition('knp_dictionary.dictionary_autowiring.123_status'));
+        Assert::false($container->hasDefinition('knp_dictionary.dictionary_autowiring.foo-bar'));
+        Assert::false($container->hasDefinition('knp_dictionary.dictionary_autowiring.foo_bar'));
     }
 
     function it_preserves_existing_named_autowiring_aliases()
@@ -240,14 +247,14 @@ final class DictionaryBuildingPassSpec extends ObjectBehavior
             (string) $container->getAlias(Dictionary::class.' $voteDictionary'),
             'app.vote_dictionary'
         );
-        Assert::false($container->hasDefinition('knp_dictionary.dictionary.vote.autowiring'));
+        Assert::false($container->hasDefinition('knp_dictionary.dictionary_autowiring.vote'));
     }
 
     private function expectDico1AliasRegistration(ContainerBuilder $container): void
     {
         $container->hasAlias(Dictionary::class.' $dico1Dictionary')->willReturn(false);
         $container->setDefinition(
-            'knp_dictionary.dictionary.dico1.autowiring',
+            'knp_dictionary.dictionary_autowiring.dico1',
             Argument::that(function ($definition): bool {
                 Assert::eq($definition->getClass(), Dictionary::class);
                 Assert::eq((string) $definition->getFactory()[0], Collection::class);
@@ -259,12 +266,12 @@ final class DictionaryBuildingPassSpec extends ObjectBehavior
         )->shouldBeCalled();
         $container
             ->registerAliasForArgument(
-                'knp_dictionary.dictionary.dico1.autowiring',
+                'knp_dictionary.dictionary_autowiring.dico1',
                 Dictionary::class,
                 'dico1.dictionary'
             )
             ->shouldBeCalled()
-            ->willReturn(new Alias('knp_dictionary.dictionary.dico1.autowiring'))
+            ->willReturn(new Alias('knp_dictionary.dictionary_autowiring.dico1'))
         ;
     }
 }

--- a/spec/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPassSpec.php
+++ b/spec/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPassSpec.php
@@ -218,6 +218,31 @@ final class DictionaryBuildingPassSpec extends ObjectBehavior
         Assert::false($container->hasAlias(Dictionary::class.' $fooBarDictionary'));
     }
 
+    function it_preserves_existing_named_autowiring_aliases()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('knp_dictionary.configuration', [
+            'dictionaries' => [
+                'vote' => [
+                    'type'    => Dictionary::VALUE,
+                    'content' => ['yes', 'no'],
+                ],
+            ],
+        ]);
+        $container
+            ->register('app.vote_dictionary', Simple::class)
+            ->setArguments(['custom_vote', ['custom']])
+        ;
+        $container->setAlias(Dictionary::class.' $voteDictionary', 'app.vote_dictionary');
+
+        $this->process($container);
+
+        Assert::same(
+            (string) $container->getAlias(Dictionary::class.' $voteDictionary'),
+            'app.vote_dictionary'
+        );
+    }
+
     private function expectDico1AliasRegistration(ContainerBuilder $container): void
     {
         $container->hasAlias(Dictionary::class.' $dico1Dictionary')->willReturn(false);

--- a/spec/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPassSpec.php
+++ b/spec/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPassSpec.php
@@ -8,8 +8,11 @@ use Knp\DictionaryBundle\DependencyInjection\Compiler\DictionaryBuildingPass;
 use Knp\DictionaryBundle\DependencyInjection\Compiler\DictionaryRegistrationPass;
 use Knp\DictionaryBundle\Dictionary;
 use Knp\DictionaryBundle\Dictionary\Factory\Aggregate;
+use Knp\DictionaryBundle\Dictionary\Simple;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Webmozart\Assert\Assert;
 
@@ -62,6 +65,7 @@ final class DictionaryBuildingPassSpec extends ObjectBehavior
                 return true;
             })
         )->shouldBeCalled();
+        $this->expectDico1AliasRegistration($container);
 
         $this->process($container);
     }
@@ -105,6 +109,7 @@ final class DictionaryBuildingPassSpec extends ObjectBehavior
                 return true;
             })
         )->shouldBeCalled();
+        $this->expectDico1AliasRegistration($container);
 
         $this->process($container);
     }
@@ -148,7 +153,103 @@ final class DictionaryBuildingPassSpec extends ObjectBehavior
                 return true;
             })
         )->shouldBeCalled();
+        $this->expectDico1AliasRegistration($container);
 
         $this->process($container);
     }
+
+    function it_autowires_configured_dictionaries_by_name()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('knp_dictionary.configuration', [
+            'dictionaries' => [
+                'vote' => [
+                    'type'    => Dictionary::VALUE,
+                    'content' => ['yes', 'no'],
+                ],
+                'entity_class_icons' => [
+                    'type'    => Dictionary::VALUE,
+                    'content' => ['user', 'group'],
+                ],
+            ],
+        ]);
+        $container->register(Aggregate::class, DictionaryFactoryStub::class);
+        $container
+            ->register(DictionaryConsumer::class, DictionaryConsumer::class)
+            ->setAutowired(true)
+            ->setPublic(true)
+        ;
+        $this->process($container);
+        $container->compile();
+
+        $consumer = $container->get(DictionaryConsumer::class);
+        Assert::isInstanceOf($consumer, DictionaryConsumer::class);
+        Assert::same($consumer->voteDictionary->getName(), 'vote');
+        Assert::same($consumer->entityClassIconsDictionary->getName(), 'entity_class_icons');
+        Assert::same($consumer->dictionary->getName(), 'vote');
+    }
+
+    function it_keeps_invalid_and_ambiguous_dictionary_names_out_of_named_autowiring()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('knp_dictionary.configuration', [
+            'dictionaries' => [
+                '123_status' => [
+                    'type'    => Dictionary::VALUE,
+                    'content' => ['draft'],
+                ],
+                'foo-bar' => [
+                    'type'    => Dictionary::VALUE,
+                    'content' => ['foo'],
+                ],
+                'foo_bar' => [
+                    'type'    => Dictionary::VALUE,
+                    'content' => ['bar'],
+                ],
+            ],
+        ]);
+
+        $this->process($container);
+
+        Assert::true($container->hasDefinition('knp_dictionary.dictionary.123_status'));
+        Assert::true($container->hasDefinition('knp_dictionary.dictionary.foo-bar'));
+        Assert::true($container->hasDefinition('knp_dictionary.dictionary.foo_bar'));
+        Assert::false($container->hasAlias(Dictionary::class.' $123StatusDictionary'));
+        Assert::false($container->hasAlias(Dictionary::class.' $fooBarDictionary'));
+    }
+
+    private function expectDico1AliasRegistration(ContainerBuilder $container): void
+    {
+        $container->hasAlias(Dictionary::class.' $dico1Dictionary')->willReturn(false);
+        $container
+            ->registerAliasForArgument(
+                'knp_dictionary.dictionary.dico1',
+                Dictionary::class,
+                'dico1.dictionary'
+            )
+            ->shouldBeCalled()
+            ->willReturn(new Alias('knp_dictionary.dictionary.dico1'))
+        ;
+    }
+}
+
+final class DictionaryFactoryStub
+{
+    /**
+     * @param mixed[] $config
+     */
+    public function create(string $name, array $config): Dictionary
+    {
+        return new Simple($name, $config['content']);
+    }
+}
+
+final class DictionaryConsumer
+{
+    public function __construct(
+        public readonly Dictionary $voteDictionary,
+        public readonly Dictionary $entityClassIconsDictionary,
+        #[Target('vote.dictionary')]
+        public readonly Dictionary $dictionary,
+    ) {}
 }

--- a/spec/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPassSpec.php
+++ b/spec/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPassSpec.php
@@ -6,9 +6,12 @@ namespace spec\Knp\DictionaryBundle\DependencyInjection\Compiler;
 
 use Knp\DictionaryBundle\DependencyInjection\Compiler\DictionaryBuildingPass;
 use Knp\DictionaryBundle\DependencyInjection\Compiler\DictionaryRegistrationPass;
+use Knp\DictionaryBundle\DependencyInjection\KnpDictionaryExtension;
 use Knp\DictionaryBundle\Dictionary;
+use Knp\DictionaryBundle\Dictionary\Collection;
 use Knp\DictionaryBundle\Dictionary\Factory\Aggregate;
 use Knp\DictionaryBundle\Dictionary\Simple;
+use Knp\DictionaryBundle\KnpDictionaryBundle;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\DependencyInjection\Alias;
@@ -161,25 +164,18 @@ final class DictionaryBuildingPassSpec extends ObjectBehavior
     function it_autowires_configured_dictionaries_by_name()
     {
         $container = new ContainerBuilder();
-        $container->setParameter('knp_dictionary.configuration', [
+        (new KnpDictionaryExtension())->load([[
             'dictionaries' => [
-                'vote' => [
-                    'type'    => Dictionary::VALUE,
-                    'content' => ['yes', 'no'],
-                ],
-                'entity_class_icons' => [
-                    'type'    => Dictionary::VALUE,
-                    'content' => ['user', 'group'],
-                ],
+                'vote'               => ['yes', 'no'],
+                'entity_class_icons' => ['user', 'group'],
             ],
-        ]);
-        $container->register(Aggregate::class, DictionaryFactoryStub::class);
+        ]], $container);
+        (new KnpDictionaryBundle())->build($container);
         $container
             ->register(DictionaryConsumer::class, DictionaryConsumer::class)
             ->setAutowired(true)
             ->setPublic(true)
         ;
-        $this->process($container);
         $container->compile();
 
         $consumer = $container->get(DictionaryConsumer::class);
@@ -216,6 +212,9 @@ final class DictionaryBuildingPassSpec extends ObjectBehavior
         Assert::true($container->hasDefinition('knp_dictionary.dictionary.foo_bar'));
         Assert::false($container->hasAlias(Dictionary::class.' $123StatusDictionary'));
         Assert::false($container->hasAlias(Dictionary::class.' $fooBarDictionary'));
+        Assert::false($container->hasDefinition('knp_dictionary.dictionary.123_status.autowiring'));
+        Assert::false($container->hasDefinition('knp_dictionary.dictionary.foo-bar.autowiring'));
+        Assert::false($container->hasDefinition('knp_dictionary.dictionary.foo_bar.autowiring'));
     }
 
     function it_preserves_existing_named_autowiring_aliases()
@@ -241,31 +240,32 @@ final class DictionaryBuildingPassSpec extends ObjectBehavior
             (string) $container->getAlias(Dictionary::class.' $voteDictionary'),
             'app.vote_dictionary'
         );
+        Assert::false($container->hasDefinition('knp_dictionary.dictionary.vote.autowiring'));
     }
 
     private function expectDico1AliasRegistration(ContainerBuilder $container): void
     {
         $container->hasAlias(Dictionary::class.' $dico1Dictionary')->willReturn(false);
+        $container->setDefinition(
+            'knp_dictionary.dictionary.dico1.autowiring',
+            Argument::that(function ($definition): bool {
+                Assert::eq($definition->getClass(), Dictionary::class);
+                Assert::eq((string) $definition->getFactory()[0], Collection::class);
+                Assert::eq($definition->getFactory()[1], 'offsetGet');
+                Assert::eq($definition->getArguments(), ['dico1']);
+
+                return true;
+            })
+        )->shouldBeCalled();
         $container
             ->registerAliasForArgument(
-                'knp_dictionary.dictionary.dico1',
+                'knp_dictionary.dictionary.dico1.autowiring',
                 Dictionary::class,
                 'dico1.dictionary'
             )
             ->shouldBeCalled()
-            ->willReturn(new Alias('knp_dictionary.dictionary.dico1'))
+            ->willReturn(new Alias('knp_dictionary.dictionary.dico1.autowiring'))
         ;
-    }
-}
-
-final class DictionaryFactoryStub
-{
-    /**
-     * @param mixed[] $config
-     */
-    public function create(string $name, array $config): Dictionary
-    {
-        return new Simple($name, $config['content']);
     }
 }
 

--- a/spec/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPassSpec.php
+++ b/spec/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPassSpec.php
@@ -68,7 +68,7 @@ final class DictionaryBuildingPassSpec extends ObjectBehavior
                 return true;
             })
         )->shouldBeCalled();
-        $this->expectDico1AliasRegistration($container);
+        $this->expectDico1Alias($container);
 
         $this->process($container);
     }
@@ -112,7 +112,7 @@ final class DictionaryBuildingPassSpec extends ObjectBehavior
                 return true;
             })
         )->shouldBeCalled();
-        $this->expectDico1AliasRegistration($container);
+        $this->expectDico1Alias($container);
 
         $this->process($container);
     }
@@ -156,7 +156,7 @@ final class DictionaryBuildingPassSpec extends ObjectBehavior
                 return true;
             })
         )->shouldBeCalled();
-        $this->expectDico1AliasRegistration($container);
+        $this->expectDico1Alias($container);
 
         $this->process($container);
     }
@@ -224,7 +224,7 @@ final class DictionaryBuildingPassSpec extends ObjectBehavior
         Assert::false($container->hasDefinition('knp_dictionary.dictionary_autowiring.foo_bar'));
     }
 
-    function it_preserves_existing_named_autowiring_aliases()
+    function it_keeps_existing_named_autowiring_aliases()
     {
         $container = new ContainerBuilder();
         $container->setParameter('knp_dictionary.configuration', [
@@ -250,7 +250,7 @@ final class DictionaryBuildingPassSpec extends ObjectBehavior
         Assert::false($container->hasDefinition('knp_dictionary.dictionary_autowiring.vote'));
     }
 
-    private function expectDico1AliasRegistration(ContainerBuilder $container): void
+    private function expectDico1Alias(ContainerBuilder $container): void
     {
         $container->hasAlias(Dictionary::class.' $dico1Dictionary')->willReturn(false);
         $container->setDefinition(

--- a/src/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPass.php
+++ b/src/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPass.php
@@ -52,11 +52,7 @@ final class DictionaryBuildingPass implements CompilerPassInterface
 
     private function normalizeArgumentName(string $name): ?string
     {
-        $words = preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $name.'.dictionary');
-
-        if (null === $words) {
-            return null;
-        }
+        $words = preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $name.'.dictionary') ?? '';
 
         $argumentName = lcfirst(str_replace(' ', '', ucwords($words)));
 

--- a/src/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPass.php
+++ b/src/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPass.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Knp\DictionaryBundle\DependencyInjection\Compiler;
 
 use Knp\DictionaryBundle\Dictionary;
+use Knp\DictionaryBundle\Dictionary\Collection;
 use Knp\DictionaryBundle\Dictionary\Factory\Aggregate;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -33,7 +34,7 @@ final class DictionaryBuildingPass implements CompilerPassInterface
             );
 
             if (null !== $argumentName = $this->normalizeArgumentName($name)) {
-                $aliases[$argumentName][] = [$serviceId, $name.'.dictionary'];
+                $aliases[$argumentName][] = [$serviceId, $name];
             }
         }
 
@@ -46,7 +47,12 @@ final class DictionaryBuildingPass implements CompilerPassInterface
                 continue;
             }
 
-            $containerBuilder->registerAliasForArgument($candidates[0][0], Dictionary::class, $candidates[0][1]);
+            $serviceId = $candidates[0][0].'.autowiring';
+            $containerBuilder->setDefinition(
+                $serviceId,
+                $this->createCollectionReferenceDefinition($candidates[0][1])
+            );
+            $containerBuilder->registerAliasForArgument($serviceId, Dictionary::class, $candidates[0][1].'.dictionary');
         }
     }
 
@@ -57,6 +63,14 @@ final class DictionaryBuildingPass implements CompilerPassInterface
         $argumentName = lcfirst(str_replace(' ', '', ucwords($words)));
 
         return 1 === preg_match('/^[a-zA-Z_\x7f-\xff]/', $argumentName) ? $argumentName : null;
+    }
+
+    private function createCollectionReferenceDefinition(string $name): Definition
+    {
+        return (new Definition(Dictionary::class))
+            ->setFactory([new Reference(Collection::class), 'offsetGet'])
+            ->addArgument($name)
+        ;
     }
 
     /**

--- a/src/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPass.php
+++ b/src/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPass.php
@@ -25,10 +25,8 @@ final class DictionaryBuildingPass implements CompilerPassInterface
         $aliases = [];
 
         foreach ($configuration['dictionaries'] as $name => $config) {
-            $serviceId = \sprintf('knp_dictionary.dictionary.%s', $name);
-
             $containerBuilder->setDefinition(
-                $serviceId,
+                \sprintf('knp_dictionary.dictionary.%s', $name),
                 $this->createDefinition($name, $config)
             );
 
@@ -57,6 +55,7 @@ final class DictionaryBuildingPass implements CompilerPassInterface
 
     private function normalizeArgumentName(string $name): ?string
     {
+        // Match Symfony's #[Target] parser, whose API differs in 5.4.
         $words = preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $name.'.dictionary') ?? '';
 
         $argumentName = lcfirst(str_replace(' ', '', ucwords($words)));
@@ -66,9 +65,8 @@ final class DictionaryBuildingPass implements CompilerPassInterface
 
     private function createCollectionReferenceDefinition(string $name): Definition
     {
-        return (new Definition(Dictionary::class))
+        return (new Definition(Dictionary::class, [$name]))
             ->setFactory([new Reference(Collection::class), 'offsetGet'])
-            ->addArgument($name)
         ;
     }
 

--- a/src/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPass.php
+++ b/src/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPass.php
@@ -22,7 +22,6 @@ final class DictionaryBuildingPass implements CompilerPassInterface
             throw new \Exception('The configuration "knp_dictionary.dictionaries" should be an array.');
         }
 
-        /** @var array<string, list<string>> $aliases */
         $aliases = [];
 
         foreach ($configuration['dictionaries'] as $name => $config) {
@@ -34,12 +33,12 @@ final class DictionaryBuildingPass implements CompilerPassInterface
             );
 
             if (null !== $argumentName = $this->normalizeArgumentName($name)) {
-                $aliases[$argumentName][] = $name;
+                $aliases[$argumentName] = \array_key_exists($argumentName, $aliases) ? null : $name;
             }
         }
 
-        foreach ($aliases as $argumentName => $candidates) {
-            if (1 !== \count($candidates)) {
+        foreach ($aliases as $argumentName => $name) {
+            if (null === $name) {
                 continue;
             }
 
@@ -47,7 +46,6 @@ final class DictionaryBuildingPass implements CompilerPassInterface
                 continue;
             }
 
-            $name      = $candidates[0];
             $serviceId = \sprintf('knp_dictionary.dictionary_autowiring.%s', $name);
             $containerBuilder->setDefinition(
                 $serviceId,

--- a/src/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPass.php
+++ b/src/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPass.php
@@ -22,7 +22,7 @@ final class DictionaryBuildingPass implements CompilerPassInterface
             throw new \Exception('The configuration "knp_dictionary.dictionaries" should be an array.');
         }
 
-        /** @var array<string, list<array{string, string}>> $aliases */
+        /** @var array<string, list<string>> $aliases */
         $aliases = [];
 
         foreach ($configuration['dictionaries'] as $name => $config) {
@@ -34,7 +34,7 @@ final class DictionaryBuildingPass implements CompilerPassInterface
             );
 
             if (null !== $argumentName = $this->normalizeArgumentName($name)) {
-                $aliases[$argumentName][] = [$serviceId, $name];
+                $aliases[$argumentName][] = $name;
             }
         }
 
@@ -47,12 +47,13 @@ final class DictionaryBuildingPass implements CompilerPassInterface
                 continue;
             }
 
-            $serviceId = $candidates[0][0].'.autowiring';
+            $name      = $candidates[0];
+            $serviceId = \sprintf('knp_dictionary.dictionary_autowiring.%s', $name);
             $containerBuilder->setDefinition(
                 $serviceId,
-                $this->createCollectionReferenceDefinition($candidates[0][1])
+                $this->createCollectionReferenceDefinition($name)
             );
-            $containerBuilder->registerAliasForArgument($serviceId, Dictionary::class, $candidates[0][1].'.dictionary');
+            $containerBuilder->registerAliasForArgument($serviceId, Dictionary::class, $name.'.dictionary');
         }
     }
 

--- a/src/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPass.php
+++ b/src/Knp/DictionaryBundle/DependencyInjection/Compiler/DictionaryBuildingPass.php
@@ -21,12 +21,46 @@ final class DictionaryBuildingPass implements CompilerPassInterface
             throw new \Exception('The configuration "knp_dictionary.dictionaries" should be an array.');
         }
 
+        /** @var array<string, list<array{string, string}>> $aliases */
+        $aliases = [];
+
         foreach ($configuration['dictionaries'] as $name => $config) {
+            $serviceId = \sprintf('knp_dictionary.dictionary.%s', $name);
+
             $containerBuilder->setDefinition(
-                \sprintf('knp_dictionary.dictionary.%s', $name),
+                $serviceId,
                 $this->createDefinition($name, $config)
             );
+
+            if (null !== $argumentName = $this->normalizeArgumentName($name)) {
+                $aliases[$argumentName][] = [$serviceId, $name.'.dictionary'];
+            }
         }
+
+        foreach ($aliases as $argumentName => $candidates) {
+            if (1 !== \count($candidates)) {
+                continue;
+            }
+
+            if ($containerBuilder->hasAlias(Dictionary::class.' $'.$argumentName)) {
+                continue;
+            }
+
+            $containerBuilder->registerAliasForArgument($candidates[0][0], Dictionary::class, $candidates[0][1]);
+        }
+    }
+
+    private function normalizeArgumentName(string $name): ?string
+    {
+        $words = preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $name.'.dictionary');
+
+        if (null === $words) {
+            return null;
+        }
+
+        $argumentName = lcfirst(str_replace(' ', '', ucwords($words)));
+
+        return 1 === preg_match('/^[a-zA-Z_\x7f-\xff]/', $argumentName) ? $argumentName : null;
     }
 
     /**


### PR DESCRIPTION
## Summary

Add named autowiring aliases for dictionaries declared through `knp_dictionary.dictionaries`.

## Details

- Inject configured dictionaries with arguments such as `Dictionary $civilityDictionary`.
- Support explicit selection with `#[Target("civility.dictionary")]`.
- Resolve named aliases through the dictionary collection to preserve the bundle initialization order.
- Keep internal autowiring services separate from configured dictionary service IDs.
- Preserve existing named aliases and suppress aliases for invalid or ambiguous normalized names.
- Document direct injection, target selection, alias precedence, and collection fallback.
- Cover the real bundle service graph, service-ID collisions, and collection access with PHPSpec.

Closes #154